### PR TITLE
Add native mobile app skeletons

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ cd ../entity-dashboard && npm install && npm run build
 
 During development you can run `npm start` in either directory to start the development server.
 
+## Mobile Apps
+
+Native mobile clients are provided in the `entity-admin-android` and `entity-admin-ios` directories.
+The Android app is written in Kotlin and can be opened directly in Android Studio.
+The iOS application uses SwiftUI and should be opened with Xcode.
+
 ## Python NFC Client
 
 `nfc_app.py` is a simple Tkinter application that can interact with the backend. Run it with Python after installing the `requests` package.

--- a/entity-admin-android/.gitignore
+++ b/entity-admin-android/.gitignore
@@ -1,0 +1,4 @@
+# Ignore Gradle build files
+/build/
+/app/build/
+/.gradle/

--- a/entity-admin-android/README.md
+++ b/entity-admin-android/README.md
@@ -1,0 +1,10 @@
+# Entity Admin Android App
+
+This is a basic Kotlin-based Android application for entity administrators.
+It uses Android's Gradle build system.
+
+## Building
+
+Open this directory in Android Studio and let it download the required
+Android SDK components. You can then run the app on an emulator or device
+using the standard Run command.

--- a/entity-admin-android/app/build.gradle
+++ b/entity-admin-android/app/build.gradle
@@ -1,0 +1,30 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace 'com.example.entityadmin'
+    compileSdk 34
+
+    defaultConfig {
+        applicationId 'com.example.entityadmin'
+        minSdk 24
+        targetSdk 34
+        versionCode 1
+        versionName '1.0'
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+dependencies {
+    implementation 'androidx.core:core-ktx:1.12.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.10.0'
+}

--- a/entity-admin-android/app/proguard-rules.pro
+++ b/entity-admin-android/app/proguard-rules.pro
@@ -1,0 +1,5 @@
+# Add project specific ProGuard rules here.
+# By default, the flags in this file are appended to flags specified
+# in /usr/local/android-sdk/tools/proguard/proguard-android.txt
+# You can edit the include path and order by changing the ProGuard
+# settings in build.gradle.

--- a/entity-admin-android/app/src/main/AndroidManifest.xml
+++ b/entity-admin-android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,14 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.entityadmin">
+
+    <application
+        android:label="@string/app_name"
+        android:theme="@style/Theme.EntityAdmin">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/entity-admin-android/app/src/main/java/com/example/entityadmin/MainActivity.kt
+++ b/entity-admin-android/app/src/main/java/com/example/entityadmin/MainActivity.kt
@@ -1,0 +1,11 @@
+package com.example.entityadmin
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+
+class MainActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+    }
+}

--- a/entity-admin-android/app/src/main/res/layout/activity_main.xml
+++ b/entity-admin-android/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <TextView
+        android:id="@+id/hello"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/hello_world"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"/>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/entity-admin-android/app/src/main/res/values/colors.xml
+++ b/entity-admin-android/app/src/main/res/values/colors.xml
@@ -1,0 +1,9 @@
+<resources>
+    <color name="purple_200">#BB86FC</color>
+    <color name="purple_500">#6200EE</color>
+    <color name="purple_700">#3700B3</color>
+    <color name="teal_200">#03DAC5</color>
+    <color name="teal_700">#018786</color>
+    <color name="black">#000000</color>
+    <color name="white">#FFFFFF</color>
+</resources>

--- a/entity-admin-android/app/src/main/res/values/strings.xml
+++ b/entity-admin-android/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<resources>
+    <string name="app_name">Entity Admin</string>
+    <string name="hello_world">Hello, Admin!</string>
+</resources>

--- a/entity-admin-android/app/src/main/res/values/themes.xml
+++ b/entity-admin-android/app/src/main/res/values/themes.xml
@@ -1,0 +1,5 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.EntityAdmin" parent="Theme.MaterialComponents.DayNight.NoActionBar">
+        <!-- Customize your theme here. -->
+    </style>
+</resources>

--- a/entity-admin-android/build.gradle
+++ b/entity-admin-android/build.gradle
@@ -1,0 +1,17 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:8.0.2'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0'
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/entity-admin-android/settings.gradle
+++ b/entity-admin-android/settings.gradle
@@ -1,0 +1,2 @@
+rootProject.name = 'EntityAdminAndroid'
+include ':app'

--- a/entity-admin-ios/.gitignore
+++ b/entity-admin-ios/.gitignore
@@ -1,0 +1,3 @@
+# Xcode build artifacts
+build/
+DerivedData/

--- a/entity-admin-ios/EntityAdminIOS/ContentView.swift
+++ b/entity-admin-ios/EntityAdminIOS/ContentView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        Text("Hello, Admin!")
+            .padding()
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/entity-admin-ios/EntityAdminIOS/EntityAdminIOSApp.swift
+++ b/entity-admin-ios/EntityAdminIOS/EntityAdminIOSApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct EntityAdminIOSApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/entity-admin-ios/EntityAdminIOS/Info.plist
+++ b/entity-admin-ios/EntityAdminIOS/Info.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleName</key>
+    <string>EntityAdmin</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.example.entityadmin</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+    <key>UILaunchStoryboardName</key>
+    <string>LaunchScreen</string>
+</dict>
+</plist>

--- a/entity-admin-ios/README.md
+++ b/entity-admin-ios/README.md
@@ -1,0 +1,5 @@
+# Entity Admin iOS App
+
+This directory contains a very small SwiftUI application for entity administrators.
+Open `EntityAdminIOS` as a new project in Xcode to build and run it on a simulator
+or device.


### PR DESCRIPTION
## Summary
- remove Expo-based mobile app
- add Kotlin Android app in `entity-admin-android`
- add SwiftUI iOS app in `entity-admin-ios`
- document new mobile apps in the root README

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68432f9aecc083239f73d9d50eb46f9e