### PR TITLE
Add basic login screen for Android app

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Native mobile clients are provided in the `entity-admin-android` and `entity-adm
 The Android app is written in Kotlin and can be opened directly in Android Studio.
 The iOS application uses SwiftUI and should be opened with Xcode.
 
+The Android client now includes a basic login screen with simple form validation.
+
 ## Python NFC Client
 
 `nfc_app.py` is a simple Tkinter application that can interact with the backend. Run it with Python after installing the `requests` package.

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,7 @@
 This checklist outlines features to implement for the native Android and iOS apps.
 
 ## Android (Kotlin)
-- [ ] Add login screen with form validation.
+- [x] Add login screen with form validation.
 - [ ] Connect to backend `/admin/authenticate` using Retrofit.
 - [ ] Store JWT token securely and attach to requests.
 - [ ] Display a list of sessions retrieved from the backend.

--- a/entity-admin-android/app/src/main/AndroidManifest.xml
+++ b/entity-admin-android/app/src/main/AndroidManifest.xml
@@ -4,11 +4,12 @@
     <application
         android:label="@string/app_name"
         android:theme="@style/Theme.EntityAdmin">
-        <activity android:name=".MainActivity">
+        <activity android:name=".LoginActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+        <activity android:name=".MainActivity" />
     </application>
 </manifest>

--- a/entity-admin-android/app/src/main/java/com/example/entityadmin/LoginActivity.kt
+++ b/entity-admin-android/app/src/main/java/com/example/entityadmin/LoginActivity.kt
@@ -1,0 +1,36 @@
+package com.example.entityadmin
+
+import android.os.Bundle
+import android.widget.Button
+import android.widget.EditText
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+
+class LoginActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_login)
+
+        val emailInput = findViewById<EditText>(R.id.editEmail)
+        val passwordInput = findViewById<EditText>(R.id.editPassword)
+        val loginButton = findViewById<Button>(R.id.buttonLogin)
+
+        loginButton.setOnClickListener {
+            val email = emailInput.text.toString().trim()
+            val password = passwordInput.text.toString()
+
+            if (email.isEmpty()) {
+                emailInput.error = getString(R.string.error_email_required)
+                return@setOnClickListener
+            }
+
+            if (password.isEmpty()) {
+                passwordInput.error = getString(R.string.error_password_required)
+                return@setOnClickListener
+            }
+
+            // Placeholder success until backend integration
+            Toast.makeText(this, R.string.login_success, Toast.LENGTH_SHORT).show()
+        }
+    }
+}

--- a/entity-admin-android/app/src/main/res/layout/activity_login.xml
+++ b/entity-admin-android/app/src/main/res/layout/activity_login.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <EditText
+        android:id="@+id/editEmail"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:hint="@string/email_hint"
+        android:inputType="textEmailAddress"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginTop="32dp" />
+
+    <EditText
+        android:id="@+id/editPassword"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:hint="@string/password_hint"
+        android:inputType="textPassword"
+        app:layout_constraintTop_toBottomOf="@id/editEmail"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginStart="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginTop="16dp" />
+
+    <Button
+        android:id="@+id/buttonLogin"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/login"
+        app:layout_constraintTop_toBottomOf="@id/editPassword"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        android:layout_marginTop="24dp" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/entity-admin-android/app/src/main/res/values/strings.xml
+++ b/entity-admin-android/app/src/main/res/values/strings.xml
@@ -1,4 +1,10 @@
 <resources>
     <string name="app_name">Entity Admin</string>
     <string name="hello_world">Hello, Admin!</string>
+    <string name="email_hint">Email</string>
+    <string name="password_hint">Password</string>
+    <string name="login">Login</string>
+    <string name="error_email_required">Email is required</string>
+    <string name="error_password_required">Password is required</string>
+    <string name="login_success">Login successful (stub)</string>
 </resources>


### PR DESCRIPTION
## Summary
- implement a simple Android login screen
- update string resources and manifest
- mark login screen TODO as complete
- note Android login screen in README

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_684335adf9e88323956cb5d8c5ac97f9