### PR TITLE
fix: Add missing validation dependency for DTOs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,10 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
+		<dependency> <!-- Added spring-boot-starter-validation -->
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
 			<artifactId>jjwt-api</artifactId>


### PR DESCRIPTION
Resolved compilation errors in `RefreshTokenRequest.java` (Cannot resolve symbol 'validation' and 'NotBlank') by adding the `spring-boot-starter-validation` dependency to `pom.xml`.

This starter provides the Jakarta Bean Validation API and its implementation (Hibernate Validator), which is necessary for using annotations like `@NotBlank`.

The import for `@NotBlank` in `RefreshTokenRequest.java` was confirmed to be correct (`jakarta.validation.constraints.NotBlank`). The issue was solely the missing dependency.