### PR TITLE
Fix duplicate org initialization

### DIFF
--- a/src/main/java/com/example/attendancesystem/config/DataInitializer.java
+++ b/src/main/java/com/example/attendancesystem/config/DataInitializer.java
@@ -33,7 +33,7 @@ public class DataInitializer {
                         return roleRepo.save(r);
                     });
 
-            Organization defaultOrg = orgRepo.findById(1L).orElseGet(() -> {
+            Organization defaultOrg = orgRepo.findByName("Default Org").orElseGet(() -> {
                 Organization o = new Organization();
                 o.setName("Default Org");
                 return orgRepo.save(o);

--- a/src/main/java/com/example/attendancesystem/repository/OrganizationRepository.java
+++ b/src/main/java/com/example/attendancesystem/repository/OrganizationRepository.java
@@ -7,4 +7,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface OrganizationRepository extends JpaRepository<Organization, Long> {
     boolean existsByName(String name);
+    java.util.Optional<Organization> findByName(String name);
 }


### PR DESCRIPTION
## Summary
- prevent duplicate `Organization` creation during startup
- add `findByName` helper to `OrganizationRepository`

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68472fd53318832f9e11c667d3b2ce0f