### PR TITLE
Add Swagger UI and endpoint docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,3 +70,12 @@ mvn test
 ## Environment
 
 The application uses an in-memory H2 database when running tests. For production you can configure another datasource in `application.properties`.
+
+## API Documentation
+
+Swagger UI is available after running the Spring Boot application. It provides an interactive interface to explore and test every endpoint.
+
+- Start the backend with `mvn spring-boot:run` or by running the packaged JAR.
+- Open <http://localhost:8080/swagger-ui.html> in your browser.
+
+From this page you can execute requests, inspect request/response models and see example values for each operation.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,86 @@
+# API Endpoints
+
+This document summarizes the REST endpoints exposed by the Spring Boot backend. All responses are JSON encoded.
+
+## Authentication
+
+### `POST /admin/authenticate`
+Authenticate a user using their username and password.
+- **Body**: `{"username": "string", "password": "string"}`
+- **Response**: `200 OK` with a payload containing an `accessToken` and `refreshToken`.
+
+### `POST /admin/refresh-token`
+Request a new access token using a previously issued refresh token.
+- **Body**: `{"refreshToken": "string"}`
+- **Response**: `200 OK` with a new `accessToken` and `refreshToken`.
+
+## Organization Administration
+Requires the `SUPER_ADMIN` role.
+
+### `POST /admin/entities`
+Create a new organization.
+- **Body**: `OrganizationDto`
+- **Response**: `201 Created` with the created organization object.
+
+### `GET /admin/entities`
+Retrieve all organizations.
+- **Response**: `200 OK` with a list of organizations.
+
+### `POST /admin/entity-admins`
+Create an entity administrator account for an organization.
+- **Body**: `EntityAdminDto`
+- **Response**: `201 Created` with the new admin information.
+
+## Entity Administration
+All routes below require the `ENTITY_ADMIN` role.
+
+### `POST /entity/subscribers`
+Add a subscriber to your organization. Optionally attach an NFC card UID.
+- **Body**: `SubscriberDto`
+- **Response**: `201 Created` with the subscriber data.
+
+### `GET /entity/subscribers`
+Get all subscribers in your organization.
+- **Response**: `200 OK` with an array of `SubscriberDto`.
+
+### `PUT /entity/subscribers/{id}`
+Update subscriber details or NFC card assignment.
+- **Body**: `SubscriberDto`
+- **Response**: `200 OK` with the updated subscriber.
+
+### `DELETE /entity/subscribers/{id}`
+Delete a subscriber and their NFC card association.
+- **Response**: `200 OK` with a confirmation message.
+
+### `POST /entity/sessions`
+Create an attendance session for your organization.
+- **Body**: `AttendanceSessionDto`
+- **Response**: `201 Created` with the created session.
+
+### `PUT /entity/sessions/{id}/end`
+End an active session.
+- **Response**: `200 OK` with the ended session data.
+
+### `GET /entity/sessions`
+List sessions for your organization.
+- **Response**: `200 OK` with an array of session objects.
+
+## NFC Scanning
+Requires authentication.
+
+### `POST /nfc/scan`
+Record an NFC card scan. Handles check-in and check-out based on session state.
+- **Body**: `NfcScanDto`
+- **Response**: `201 Created` or `200 OK` with a status message.
+
+## Reports
+Requires the `ENTITY_ADMIN` role.
+
+### `GET /reports/sessions/{sessionId}/absentees`
+List subscribers who did not attend a session.
+- **Response**: `200 OK` with an array of absent subscribers.
+
+### `GET /reports/subscribers/{subscriberId}/attendance`
+Retrieve attendance logs for a subscriber within an optional date range.
+- **Query Params**: `startDate` and `endDate` in ISO format.
+- **Response**: `200 OK` with an array of attendance logs.

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
 	<properties>
 		<java.version>17</java.version>
 	</properties>
-	<dependencies>
+        <dependencies>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-jpa</artifactId>
@@ -38,10 +38,16 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-web</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-web</artifactId>
+                </dependency>
+                <!-- Swagger UI via springdoc-openapi -->
+                <dependency>
+                        <groupId>org.springdoc</groupId>
+                        <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+                        <version>2.8.6</version>
+                </dependency>
 		<dependency> <!-- Added spring-boot-starter-validation -->
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>

--- a/src/main/java/com/example/attendancesystem/config/OpenApiConfig.java
+++ b/src/main/java/com/example/attendancesystem/config/OpenApiConfig.java
@@ -1,0 +1,23 @@
+package com.example.attendancesystem.config;
+
+import io.swagger.v3.oas.models.ExternalDocumentation;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenApiConfig {
+    @Bean
+    public OpenAPI attendanceSystemOpenAPI() {
+        return new OpenAPI()
+                .info(new Info().title("Attendance System API")
+                        .description("API documentation for the Attendance Management System")
+                        .version("v1.0")
+                        .license(new License().name("Apache 2.0")))
+                .externalDocs(new ExternalDocumentation()
+                        .description("Project README")
+                        .url("https://example.com"));
+    }
+}


### PR DESCRIPTION
## Summary
- integrate `springdoc-openapi` so the API can be tested via Swagger UI
- document the API endpoints
- explain how to reach Swagger UI

## Testing
- `./mvnw -q test` *(fails: cannot resolve Spring Boot parent due to network)*

------
https://chatgpt.com/codex/tasks/task_e_684732aa4af0832f8ac67f8190676b55