### PR TITLE
Fix substring name in report test

### DIFF
--- a/src/test/java/com/example/attendancesystem/controller/ReportControllerTest.java
+++ b/src/test/java/com/example/attendancesystem/controller/ReportControllerTest.java
@@ -63,7 +63,7 @@ public class ReportControllerTest {
         org2 = organizationRepository.findByName("Test Org Two (EntityController)").orElseThrow();
 
         // Subscribers for Org1
-        sub1Org1 = subscriberRepository.save(new Subscriber(" présentsub1", "lastname", "present1@org1.com", org1, null));
+        sub1Org1 = subscriberRepository.save(new Subscriber("presentsub1", "lastname", "present1@org1.com", org1, null));
         sub2Org1 = subscriberRepository.save(new Subscriber("absentsub2", "lastname", "absent2@org1.com", org1, null));
         sub3Org1 = subscriberRepository.save(new Subscriber("presentsub3", "lastname", "present3@org1.com", org1, null));
 


### PR DESCRIPTION
## Summary
- fix test data subscriber name in ReportControllerTest

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6847bbf9aee0832faf24370bf44e7b3f