### PR TITLE
Fix entity ID extraction in face controllers

### DIFF
--- a/src/main/java/com/example/attendancesystem/controller/FaceRecognitionAdvancedSettingsController.java
+++ b/src/main/java/com/example/attendancesystem/controller/FaceRecognitionAdvancedSettingsController.java
@@ -1,6 +1,7 @@
 package com.example.attendancesystem.controller;
 
 import com.example.attendancesystem.service.FaceRecognitionSettingsService;
+import com.example.attendancesystem.util.AuthUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -414,20 +415,6 @@ public class FaceRecognitionAdvancedSettingsController {
      * Helper method to extract entity ID from authentication
      */
     private String getEntityIdFromAuthentication(Authentication authentication) {
-        if (authentication != null && authentication.getPrincipal() instanceof org.springframework.security.core.userdetails.UserDetails) {
-            String username = authentication.getName();
-            return extractEntityIdFromUsername(username);
-        }
-        throw new IllegalArgumentException("Unable to determine entity ID from authentication");
-    }
-
-    /**
-     * Helper method to extract entity ID from username
-     */
-    private String extractEntityIdFromUsername(String username) {
-        if (username != null && username.contains("@")) {
-            return username.split("@")[1];
-        }
-        return "MSD00001"; // Default fallback
+        return com.example.attendancesystem.util.AuthUtil.getEntityId(authentication);
     }
 }

--- a/src/main/java/com/example/attendancesystem/controller/FaceRecognitionCheckInController.java
+++ b/src/main/java/com/example/attendancesystem/controller/FaceRecognitionCheckInController.java
@@ -5,6 +5,7 @@ import com.example.attendancesystem.facerecognition.FaceRecognitionResult;
 import com.example.attendancesystem.model.*;
 import com.example.attendancesystem.repository.*;
 import com.example.attendancesystem.service.*;
+import com.example.attendancesystem.util.AuthUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -449,21 +450,7 @@ public class FaceRecognitionCheckInController {
      * Helper method to extract entity ID from authentication
      */
     private String getEntityIdFromAuthentication(Authentication authentication) {
-        if (authentication != null && authentication.getPrincipal() instanceof org.springframework.security.core.userdetails.UserDetails) {
-            String username = authentication.getName();
-            return extractEntityIdFromUsername(username);
-        }
-        throw new IllegalArgumentException("Unable to determine entity ID from authentication");
-    }
-
-    /**
-     * Helper method to extract entity ID from username
-     */
-    private String extractEntityIdFromUsername(String username) {
-        if (username != null && username.contains("@")) {
-            return username.split("@")[1];
-        }
-        return "MSD00001"; // Default fallback
+        return com.example.attendancesystem.util.AuthUtil.getEntityId(authentication);
     }
 
     /**

--- a/src/main/java/com/example/attendancesystem/controller/FaceRecognitionSettingsController.java
+++ b/src/main/java/com/example/attendancesystem/controller/FaceRecognitionSettingsController.java
@@ -3,6 +3,7 @@ package com.example.attendancesystem.controller;
 import com.example.attendancesystem.model.FaceRecognitionSettings;
 import com.example.attendancesystem.repository.FaceRecognitionSettingsRepository;
 import com.example.attendancesystem.service.FaceRecognitionService;
+import com.example.attendancesystem.util.AuthUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -453,20 +454,6 @@ public class FaceRecognitionSettingsController {
      * Helper method to extract entity ID from authentication
      */
     private String getEntityIdFromAuthentication(Authentication authentication) {
-        if (authentication != null && authentication.getPrincipal() instanceof org.springframework.security.core.userdetails.UserDetails) {
-            String username = authentication.getName();
-            return extractEntityIdFromUsername(username);
-        }
-        throw new IllegalArgumentException("Unable to determine entity ID from authentication");
-    }
-
-    /**
-     * Helper method to extract entity ID from username
-     */
-    private String extractEntityIdFromUsername(String username) {
-        if (username != null && username.contains("@")) {
-            return username.split("@")[1];
-        }
-        return "MSD00001"; // Default fallback
+        return com.example.attendancesystem.util.AuthUtil.getEntityId(authentication);
     }
 }

--- a/src/main/java/com/example/attendancesystem/controller/FaceRegistrationController.java
+++ b/src/main/java/com/example/attendancesystem/controller/FaceRegistrationController.java
@@ -6,6 +6,7 @@ import com.example.attendancesystem.model.Subscriber;
 import com.example.attendancesystem.repository.SubscriberRepository;
 import com.example.attendancesystem.service.FaceRecognitionService;
 import com.example.attendancesystem.service.FileStorageService;
+import com.example.attendancesystem.util.AuthUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -479,36 +480,7 @@ public class FaceRegistrationController {
      * Helper method to extract entity ID from authentication
      */
     private String getEntityIdFromAuthentication(Authentication authentication) {
-        // Extract entity ID from JWT token or authentication principal
-        // This should match your existing authentication implementation
-        if (authentication != null && authentication.getPrincipal() instanceof org.springframework.security.core.userdetails.UserDetails) {
-            // For entity admin authentication, extract entity ID from username or custom claims
-            String username = authentication.getName();
-            // Assuming username format or custom implementation to get entity ID
-            // You may need to adjust this based on your JWT token structure
-            return extractEntityIdFromUsername(username);
-        }
-        throw new IllegalArgumentException("Unable to determine entity ID from authentication");
-    }
-
-    /**
-     * Helper method to extract entity ID from username
-     * Adjust this method based on your authentication implementation
-     */
-    private String extractEntityIdFromUsername(String username) {
-        // This is a placeholder implementation
-        // You should implement this based on your actual authentication structure
-        // For example, if entity ID is stored in JWT claims or user details
-
-        // Temporary implementation - you may need to modify this
-        // to match your actual authentication system
-        if (username != null && username.contains("@")) {
-            // If username format includes entity info
-            return username.split("@")[1]; // Example format: admin@MSD00001
-        }
-
-        // Default fallback - you should implement proper entity ID extraction
-        return "MSD00001"; // This should be replaced with actual implementation
+        return com.example.attendancesystem.util.AuthUtil.getEntityId(authentication);
     }
 
     /**

--- a/src/main/java/com/example/attendancesystem/util/AuthUtil.java
+++ b/src/main/java/com/example/attendancesystem/util/AuthUtil.java
@@ -1,0 +1,29 @@
+package com.example.attendancesystem.util;
+
+import com.example.attendancesystem.security.CustomUserDetails;
+import com.example.attendancesystem.model.EntityAdmin;
+import org.springframework.security.core.Authentication;
+
+/**
+ * Utility methods for extracting information from Authentication objects.
+ */
+public final class AuthUtil {
+    private AuthUtil() {}
+
+    /**
+     * Extract the entity ID from the authenticated principal.
+     *
+     * @param authentication the Authentication object
+     * @return the entity ID
+     * @throws IllegalArgumentException if the entity ID cannot be determined
+     */
+    public static String getEntityId(Authentication authentication) {
+        if (authentication != null && authentication.getPrincipal() instanceof CustomUserDetails userDetails) {
+            EntityAdmin admin = userDetails.getEntityAdmin();
+            if (admin != null && admin.getOrganization() != null) {
+                return admin.getOrganization().getEntityId();
+            }
+        }
+        throw new IllegalArgumentException("Unable to determine entity ID from authentication");
+    }
+}


### PR DESCRIPTION
## Summary
- add `AuthUtil` helper to pull entity ID from `Authentication`
- use the helper in face-related controllers

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network)*
- `mvn -q -DskipTests=true package` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_6850a66393e48323a55ad9e5f3aa2ba3